### PR TITLE
Migrate to Zig 0.16.0

### DIFF
--- a/benchmarks/benchmark.zig
+++ b/benchmarks/benchmark.zig
@@ -298,7 +298,7 @@ const BenchmarkSuite: []const BenchmarkSpec = &[_]BenchmarkSpec{
 ////////////////////////////////////////////////////////////////////////////////
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     const allocator = gpa.allocator();
 
     const args = try std.process.argsAlloc(allocator);

--- a/benchmarks/benchmark.zig
+++ b/benchmarks/benchmark.zig
@@ -12,9 +12,18 @@ const BENCHMARK_TRIAL_DURATION_MS = 5000;
 // Helpers
 ////////////////////////////////////////////////////////////////////////////////
 
+// Zig 0.16 removed std.Thread.sleep; use libC nanosleep.
+fn sleepMs(milliseconds: u64) void {
+    const ts: std.c.timespec = .{
+        .sec = @intCast(milliseconds / 1000),
+        .nsec = @intCast((milliseconds % 1000) * 1_000_000),
+    };
+    _ = std.c.nanosleep(&ts, null);
+}
+
 fn benchmark_run(flowgraph: *radio.Flowgraph) !void {
     try flowgraph.start();
-    std.Thread.sleep(BENCHMARK_TRIAL_DURATION_MS * 1e6);
+    sleepMs(BENCHMARK_TRIAL_DURATION_MS);
     _ = try flowgraph.stop();
 }
 
@@ -297,14 +306,12 @@ const BenchmarkSuite: []const BenchmarkSpec = &[_]BenchmarkSpec{
 // Entry Point
 ////////////////////////////////////////////////////////////////////////////////
 
-pub fn main() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
 
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
-
-    const benchmark_filter: ?[]const u8 = if (args.len > 1) args[1] else null;
+    var args_it = std.process.Args.Iterator.init(init.minimal.args);
+    _ = args_it.next(); // skip program name
+    const benchmark_filter: ?[]const u8 = args_it.next();
 
     for (BenchmarkSuite) |benchmark| {
         if (benchmark_filter != null and std.ascii.indexOfIgnoreCase(benchmark.name, benchmark_filter.?) == null) continue;

--- a/build.zig
+++ b/build.zig
@@ -5,14 +5,14 @@ const Example = struct {
     path: []const u8,
 };
 
-fn discoverExamples(allocator: std.mem.Allocator, dir_path: []const u8) !std.array_list.Managed(Example) {
+fn discoverExamples(allocator: std.mem.Allocator, io: std.Io, dir_path: []const u8) !std.array_list.Managed(Example) {
     var examples = std.array_list.Managed(Example).init(allocator);
 
-    var examples_dir = try std.fs.cwd().openDir(dir_path, .{ .iterate = true });
-    defer examples_dir.close();
+    var examples_dir = try std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true });
+    defer examples_dir.close(io);
 
     var examples_it = examples_dir.iterate();
-    while (try examples_it.next()) |entry| {
+    while (try examples_it.next(io)) |entry| {
         if (entry.kind == .file and std.mem.endsWith(u8, entry.name, ".zig")) {
             const name = try std.mem.concat(allocator, u8, &[_][]const u8{ "example-", entry.name[0 .. entry.name.len - 4] });
             const path = try std.fs.path.join(allocator, &[_][]const u8{ "examples", entry.name });
@@ -31,7 +31,7 @@ pub fn build(b: *std.Build) !void {
     const radio_module = b.addModule("radio", .{ .root_source_file = b.path("src/radio.zig") });
 
     // Discover examples
-    const examples = try discoverExamples(b.allocator, b.path("examples").getPath(b));
+    const examples = try discoverExamples(b.allocator, b.graph.io, b.path("examples").getPath(b));
 
     // Build examples
     const examples_step = b.step("examples", "Build examples");
@@ -42,10 +42,10 @@ pub fn build(b: *std.Build) !void {
                 .root_source_file = b.path(example.path),
                 .target = target,
                 .optimize = .ReleaseFast,
+                .link_libc = true,
             }),
         });
         example_exe.root_module.addImport("radio", radio_module);
-        example_exe.linkLibC();
         const install_example = b.addInstallArtifact(example_exe, .{});
 
         examples_step.dependOn(&install_example.step);
@@ -57,9 +57,9 @@ pub fn build(b: *std.Build) !void {
             .root_source_file = b.path("src/radio.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
-    tests.linkLibC();
     const run_tests = b.addRunArtifact(tests);
     run_tests.has_side_effects = true;
     const test_step = b.step("test", "Run framework tests");
@@ -72,10 +72,10 @@ pub fn build(b: *std.Build) !void {
             .root_source_file = b.path("benchmarks/benchmark.zig"),
             .target = target,
             .optimize = .ReleaseFast,
+            .link_libc = true,
         }),
     });
     benchmark_suite.root_module.addImport("radio", radio_module);
-    benchmark_suite.linkLibC();
     const run_benchmark_suite = b.addRunArtifact(benchmark_suite);
     if (b.args) |args| run_benchmark_suite.addArgs(args);
     const benchmark_step = b.step("benchmark", "Run benchmark suite");

--- a/examples/iqfile_converter.zig
+++ b/examples/iqfile_converter.zig
@@ -2,33 +2,36 @@ const std = @import("std");
 
 const radio = @import("radio");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
 
-    const args = try std.process.argsAlloc(gpa.allocator());
-    defer std.process.argsFree(gpa.allocator(), args);
-
-    if (args.len < 5) {
-        std.debug.print("Usage: {s} <input IQ file> <input format> <output IQ file> <output format>\n", .{args[0]});
+    var args_it = std.process.Args.Iterator.init(init.minimal.args);
+    const prog = args_it.next() orelse "example";
+    const input_path = args_it.next();
+    const input_format_arg = args_it.next();
+    const output_path = args_it.next();
+    const output_format_arg = args_it.next();
+    if (output_format_arg == null) {
+        std.debug.print("Usage: {s} <input IQ file> <input format> <output IQ file> <output format>\n", .{prog});
         std.debug.print("Supported formats: u8, s8, u16le, u16be, s16le, s16be, u32le, u32be, s32le, s32be, f32le, f32be, f64le, f64be\n", .{});
-        std.posix.exit(1);
+        std.process.exit(1);
     }
 
-    const input_format = std.meta.stringToEnum(radio.utils.sample_format.SampleFormat, args[2]) orelse return error.InvalidArgument;
-    const output_format = std.meta.stringToEnum(radio.utils.sample_format.SampleFormat, args[4]) orelse return error.InvalidArgument;
+    const input_format = std.meta.stringToEnum(radio.utils.sample_format.SampleFormat, input_format_arg.?) orelse return error.InvalidArgument;
+    const output_format = std.meta.stringToEnum(radio.utils.sample_format.SampleFormat, output_format_arg.?) orelse return error.InvalidArgument;
 
-    var input_file = try std.fs.cwd().openFile(args[1], .{});
-    defer input_file.close();
-    var output_file = try std.fs.cwd().createFile(args[3], .{});
-    defer output_file.close();
+    var input_file = try std.Io.Dir.cwd().openFile(io, input_path.?, .{});
+    defer input_file.close(io);
+    var output_file = try std.Io.Dir.cwd().createFile(io, output_path.?, .{});
+    defer output_file.close(io);
 
-    var input_reader = input_file.reader(&.{});
-    var output_writer = output_file.writer(&.{});
+    var input_reader = input_file.reader(io, &.{});
+    var output_writer = output_file.writer(io, &.{});
 
     var source = radio.blocks.IQStreamSource.init(&input_reader.interface, input_format, 0, .{});
     var sink = radio.blocks.IQStreamSink.init(&output_writer.interface, output_format, .{});
 
-    var top = radio.Flowgraph.init(gpa.allocator(), .{ .debug = true });
+    var top = radio.Flowgraph.init(init.gpa, .{ .debug = true });
     defer top.deinit();
     try top.connect(&source.block, &sink.block);
 

--- a/examples/play_tone.zig
+++ b/examples/play_tone.zig
@@ -2,13 +2,11 @@ const std = @import("std");
 
 const radio = @import("radio");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-
+pub fn main(init: std.process.Init) !void {
     var source = radio.blocks.SignalSource.init(radio.blocks.SignalSource.WaveformFunction.Cosine, 440, 44100, .{});
     var sink = radio.blocks.PulseAudioSink(1).init();
 
-    var top = radio.Flowgraph.init(gpa.allocator(), .{ .debug = true });
+    var top = radio.Flowgraph.init(init.gpa, .{ .debug = true });
     defer top.deinit();
     try top.connect(&source.block, &sink.block);
 

--- a/examples/rtlsdr_am_envelope.zig
+++ b/examples/rtlsdr_am_envelope.zig
@@ -2,18 +2,16 @@ const std = @import("std");
 
 const radio = @import("radio");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-
-    const args = try std.process.argsAlloc(gpa.allocator());
-    defer std.process.argsFree(gpa.allocator(), args);
-
-    if (args.len < 2) {
-        std.debug.print("Usage: {s} <frequency>\n", .{args[0]});
-        std.posix.exit(1);
+pub fn main(init: std.process.Init) !void {
+    var args_it = std.process.Args.Iterator.init(init.minimal.args);
+    const prog = args_it.next() orelse "example";
+    const frequency_arg = args_it.next();
+    if (frequency_arg == null) {
+        std.debug.print("Usage: {s} <frequency>\n", .{prog});
+        std.process.exit(1);
     }
 
-    const frequency = try std.fmt.parseFloat(f64, args[1]);
+    const frequency = try std.fmt.parseFloat(f64, frequency_arg.?);
     const tune_offset = -50e3;
     const bandwidth = 5e3;
 
@@ -26,7 +24,7 @@ pub fn main() !void {
     var af_downsampler = radio.blocks.DownsamplerBlock(f32).init(2);
     var sink = radio.blocks.PulseAudioSink(1).init();
 
-    var top = radio.Flowgraph.init(gpa.allocator(), .{ .debug = true });
+    var top = radio.Flowgraph.init(init.gpa, .{ .debug = true });
     defer top.deinit();
     try top.connect(&source.block, &tuner.block);
     try top.connect(&tuner.block, &am_demod.block);

--- a/examples/rtlsdr_am_synchronous.zig
+++ b/examples/rtlsdr_am_synchronous.zig
@@ -2,18 +2,16 @@ const std = @import("std");
 
 const radio = @import("radio");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-
-    const args = try std.process.argsAlloc(gpa.allocator());
-    defer std.process.argsFree(gpa.allocator(), args);
-
-    if (args.len < 2) {
-        std.debug.print("Usage: {s} <frequency>\n", .{args[0]});
-        std.posix.exit(1);
+pub fn main(init: std.process.Init) !void {
+    var args_it = std.process.Args.Iterator.init(init.minimal.args);
+    const prog = args_it.next() orelse "example";
+    const frequency_arg = args_it.next();
+    if (frequency_arg == null) {
+        std.debug.print("Usage: {s} <frequency>\n", .{prog});
+        std.process.exit(1);
     }
 
-    const frequency = try std.fmt.parseFloat(f64, args[1]);
+    const frequency = try std.fmt.parseFloat(f64, frequency_arg.?);
     const tune_offset = -50e3;
     const bandwidth = 5e3;
 
@@ -28,7 +26,7 @@ pub fn main() !void {
     var af_downsampler = radio.blocks.DownsamplerBlock(f32).init(2);
     var sink = radio.blocks.PulseAudioSink(1).init();
 
-    var top = radio.Flowgraph.init(gpa.allocator(), .{ .debug = true });
+    var top = radio.Flowgraph.init(init.gpa, .{ .debug = true });
     defer top.deinit();
     try top.connect(&source.block, &tuner.block);
     try top.connect(&tuner.block, &pll.block);

--- a/examples/rtlsdr_nbfm.zig
+++ b/examples/rtlsdr_nbfm.zig
@@ -2,18 +2,16 @@ const std = @import("std");
 
 const radio = @import("radio");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-
-    const args = try std.process.argsAlloc(gpa.allocator());
-    defer std.process.argsFree(gpa.allocator(), args);
-
-    if (args.len < 2) {
-        std.debug.print("Usage: {s} <frequency>\n", .{args[0]});
-        std.posix.exit(1);
+pub fn main(init: std.process.Init) !void {
+    var args_it = std.process.Args.Iterator.init(init.minimal.args);
+    const prog = args_it.next() orelse "example";
+    const frequency_arg = args_it.next();
+    if (frequency_arg == null) {
+        std.debug.print("Usage: {s} <frequency>\n", .{prog});
+        std.process.exit(1);
     }
 
-    const frequency = try std.fmt.parseFloat(f64, args[1]);
+    const frequency = try std.fmt.parseFloat(f64, frequency_arg.?);
     const tune_offset = -50e3;
     const deviation = 5e3;
     const bandwidth = 4e3;
@@ -25,7 +23,7 @@ pub fn main() !void {
     var af_downsampler = radio.blocks.DownsamplerBlock(f32).init(2);
     var sink = radio.blocks.PulseAudioSink(1).init();
 
-    var top = radio.Flowgraph.init(gpa.allocator(), .{ .debug = true });
+    var top = radio.Flowgraph.init(init.gpa, .{ .debug = true });
     defer top.deinit();
     try top.connect(&source.block, &tuner.block);
     try top.connect(&tuner.block, &fm_demod.block);

--- a/examples/rtlsdr_ssb.zig
+++ b/examples/rtlsdr_ssb.zig
@@ -2,19 +2,18 @@ const std = @import("std");
 
 const radio = @import("radio");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-
-    const args = try std.process.argsAlloc(gpa.allocator());
-    defer std.process.argsFree(gpa.allocator(), args);
-
-    if (args.len < 3) {
-        std.debug.print("Usage: {s} <frequency> <sideband>\n", .{args[0]});
-        std.posix.exit(1);
+pub fn main(init: std.process.Init) !void {
+    var args_it = std.process.Args.Iterator.init(init.minimal.args);
+    const prog = args_it.next() orelse "example";
+    const frequency_arg = args_it.next();
+    const sideband_arg = args_it.next();
+    if (sideband_arg == null) {
+        std.debug.print("Usage: {s} <frequency> <sideband>\n", .{prog});
+        std.process.exit(1);
     }
 
-    const frequency = try std.fmt.parseFloat(f64, args[1]);
-    const sideband: enum { LSB, USB } = if (std.mem.eql(u8, args[2], "lsb")) .LSB else .USB;
+    const frequency = try std.fmt.parseFloat(f64, frequency_arg.?);
+    const sideband: enum { LSB, USB } = if (std.mem.eql(u8, sideband_arg.?, "lsb")) .LSB else .USB;
     const tune_offset = -50e3;
     const bandwidth = 3e3;
 
@@ -27,7 +26,7 @@ pub fn main() !void {
     var af_downsampler = radio.blocks.DownsamplerBlock(f32).init(2);
     var sink = radio.blocks.PulseAudioSink(1).init();
 
-    var top = radio.Flowgraph.init(gpa.allocator(), .{ .debug = true });
+    var top = radio.Flowgraph.init(init.gpa, .{ .debug = true });
     defer top.deinit();
     try top.connect(&source.block, &tuner.block);
     try top.connect(&tuner.block, &sb_filter.block);

--- a/examples/rtlsdr_wbfm_mono.zig
+++ b/examples/rtlsdr_wbfm_mono.zig
@@ -2,18 +2,16 @@ const std = @import("std");
 
 const radio = @import("radio");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-
-    const args = try std.process.argsAlloc(gpa.allocator());
-    defer std.process.argsFree(gpa.allocator(), args);
-
-    if (args.len < 2) {
-        std.debug.print("Usage: {s} <FM radio frequency>\n", .{args[0]});
-        std.posix.exit(1);
+pub fn main(init: std.process.Init) !void {
+    var args_it = std.process.Args.Iterator.init(init.minimal.args);
+    const prog = args_it.next() orelse "example";
+    const frequency_arg = args_it.next();
+    if (frequency_arg == null) {
+        std.debug.print("Usage: {s} <FM radio frequency>\n", .{prog});
+        std.process.exit(1);
     }
 
-    const frequency = try std.fmt.parseFloat(f64, args[1]);
+    const frequency = try std.fmt.parseFloat(f64, frequency_arg.?);
     const tune_offset = -250e3;
 
     var source = radio.blocks.RtlSdrSource.init(frequency + tune_offset, 960000, .{ .debug = true });
@@ -24,7 +22,7 @@ pub fn main() !void {
     var af_downsampler = radio.blocks.DownsamplerBlock(f32).init(5);
     var sink = radio.blocks.PulseAudioSink(1).init();
 
-    var top = radio.Flowgraph.init(gpa.allocator(), .{ .debug = true });
+    var top = radio.Flowgraph.init(init.gpa, .{ .debug = true });
     defer top.deinit();
     try top.connect(&source.block, &tuner.block);
     try top.connect(&tuner.block, &fm_demod.block);

--- a/examples/rtlsdr_wbfm_stereo.zig
+++ b/examples/rtlsdr_wbfm_stereo.zig
@@ -2,18 +2,16 @@ const std = @import("std");
 
 const radio = @import("radio");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-
-    const args = try std.process.argsAlloc(gpa.allocator());
-    defer std.process.argsFree(gpa.allocator(), args);
-
-    if (args.len < 2) {
-        std.debug.print("Usage: {s} <FM radio frequency>\n", .{args[0]});
-        std.posix.exit(1);
+pub fn main(init: std.process.Init) !void {
+    var args_it = std.process.Args.Iterator.init(init.minimal.args);
+    const prog = args_it.next() orelse "example";
+    const frequency_arg = args_it.next();
+    if (frequency_arg == null) {
+        std.debug.print("Usage: {s} <FM radio frequency>\n", .{prog});
+        std.process.exit(1);
     }
 
-    const frequency = try std.fmt.parseFloat(f64, args[1]);
+    const frequency = try std.fmt.parseFloat(f64, frequency_arg.?);
     const tune_offset = -250e3;
 
     var source = radio.blocks.RtlSdrSource.init(frequency + tune_offset, 960000, .{ .debug = true });
@@ -40,7 +38,7 @@ pub fn main() !void {
     var r_af_downsampler = radio.blocks.DownsamplerBlock(f32).init(5);
     var sink = radio.blocks.PulseAudioSink(2).init();
 
-    var top = radio.Flowgraph.init(gpa.allocator(), .{ .debug = true });
+    var top = radio.Flowgraph.init(init.gpa, .{ .debug = true });
     defer top.deinit();
     try top.connect(&source.block, &tuner.block);
     try top.connect(&tuner.block, &fm_demod.block);

--- a/src/blocks/signal/frequencytranslator.zig
+++ b/src/blocks/signal/frequencytranslator.zig
@@ -184,7 +184,7 @@ pub const _FrequencyTranslatorBlockZigImpl = struct {
         }
 
         while (@abs(self.phase) > 2 * std.math.pi) {
-            self.phase -= std.math.sign(self.omega) * 2 * std.math.pi;
+            self.phase -= std.math.copysign(@as(@TypeOf(self.phase), 2 * std.math.pi), self.omega);
         }
 
         return ProcessResult.init(&[1]usize{x.len}, &[1]usize{x.len});

--- a/src/blocks/sinks/application.zig
+++ b/src/blocks/sinks/application.zig
@@ -38,6 +38,7 @@
 // const sample = snk.pop();
 
 const std = @import("std");
+const sync = @import("../../core/sync.zig");
 
 const Block = @import("../../radio.zig").Block;
 const SampleMux = @import("../../core/sample_mux.zig").SampleMux;
@@ -232,7 +233,7 @@ test "ApplicationSink blocking read" {
     try std.testing.expectError(error.Timeout, application_sink.wait(1, std.time.ns_per_ms));
 
     const BufferWaiter = struct {
-        fn run(sink: *ApplicationSink(u32), done: *std.Thread.ResetEvent) !void {
+        fn run(sink: *ApplicationSink(u32), done: *sync.ResetEvent) !void {
             // Wait for two samples availability
             try sink.wait(2, null);
             // Signal done
@@ -241,7 +242,7 @@ test "ApplicationSink blocking read" {
     };
 
     // Spawn a thread that blocks until two samples are available
-    var done_event = std.Thread.ResetEvent{};
+    var done_event = sync.ResetEvent{};
     var thread = try std.Thread.spawn(.{}, BufferWaiter.run, .{ &application_sink, &done_event });
 
     // Check thread is blocking

--- a/src/blocks/sinks/benchmark.zig
+++ b/src/blocks/sinks/benchmark.zig
@@ -17,6 +17,15 @@ const std = @import("std");
 const Block = @import("../../radio.zig").Block;
 const ProcessResult = @import("../../radio.zig").ProcessResult;
 
+// Zig 0.16 removed std.time.milliTimestamp; use libC clock_gettime.
+extern "c" fn clock_gettime(clk_id: std.c.clockid_t, tp: *std.c.timespec) c_int;
+
+fn milliTimestamp() u64 {
+    var ts: std.c.timespec = undefined;
+    _ = clock_gettime(std.c.CLOCK.REALTIME, &ts);
+    return @as(u64, @intCast(ts.sec)) * 1000 + @as(u64, @intCast(ts.nsec)) / 1_000_000;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Benchmark Sink
 ////////////////////////////////////////////////////////////////////////////////
@@ -41,11 +50,11 @@ pub fn BenchmarkSink(comptime T: type) type {
 
         pub fn initialize(self: *Self, _: std.mem.Allocator) !void {
             self.count = 0;
-            self.tic_ms = @as(u64, @intCast(std.time.milliTimestamp()));
+            self.tic_ms = milliTimestamp();
         }
 
         pub fn deinitialize(self: *Self, _: std.mem.Allocator) void {
-            const toc_ms = @as(u64, @intCast(std.time.milliTimestamp()));
+            const toc_ms = milliTimestamp();
             self.report(toc_ms);
         }
 
@@ -81,7 +90,7 @@ pub fn BenchmarkSink(comptime T: type) type {
         pub fn process(self: *Self, x: []const T) !ProcessResult {
             self.count += x.len;
 
-            const toc_ms = @as(u64, @intCast(std.time.milliTimestamp()));
+            const toc_ms = milliTimestamp();
             if (toc_ms - self.tic_ms > self.options.report_period_ms) {
                 self.report(toc_ms);
             }

--- a/src/blocks/sinks/iqstream.zig
+++ b/src/blocks/sinks/iqstream.zig
@@ -2,7 +2,7 @@
 // @description Sink a complex-valued signal to a binary stream, using the
 // specified sample format.
 // @category Sinks
-// @param writer *std.io.Writer Writer
+// @param writer *std.Io.Writer Writer
 // @param format SampleFormat Choice of s8, u8, u16le, u16be, s16le, s16be, u32le, u32be, s32le, s32be, f32le, f32be, f64le, f64be
 // @param options Options Additional options
 // @signature in1:Complex(f32) >
@@ -31,13 +31,13 @@ pub const IQStreamSink = struct {
     pub const Options = struct {};
 
     block: Block,
-    writer: *std.io.Writer,
+    writer: *std.Io.Writer,
     options: Options,
 
     converter: SampleFormat.Converter,
     buffer: [16384]u8 = undefined,
 
-    pub fn init(writer: *std.io.Writer, format: SampleFormat, options: Options) Self {
+    pub fn init(writer: *std.Io.Writer, format: SampleFormat, options: Options) Self {
         return .{ .block = Block.init(@This()), .writer = writer, .options = options, .converter = format.converter() };
     }
 
@@ -67,7 +67,7 @@ const vectors = @import("../../vectors/utils/sample_format.zig");
 
 test "IQStreamSink" {
     var buf: [64]u8 = undefined;
-    var writer = std.io.Writer.fixed(&buf);
+    var writer = std.Io.Writer.fixed(&buf);
 
     // Basic test
     var block = IQStreamSink.init(&writer, .u16be, .{});
@@ -79,7 +79,7 @@ test "IQStreamSink" {
 
     try std.testing.expectEqualSlices(u8, &vectors.bytes_complex_u16be, writer.buffered());
 
-    writer = std.io.Writer.fixed(&buf);
+    writer = std.Io.Writer.fixed(&buf);
 
     // Test sample by sample
     for (vectors.input_complex_samples) |sample| {

--- a/src/blocks/sinks/jsonstream.zig
+++ b/src/blocks/sinks/jsonstream.zig
@@ -3,7 +3,7 @@
 // are serialized individually and newline delimited.
 // @category Sinks
 // @ctparam T type Any type serializable by `std.json.stringify()`
-// @param writer *std.io.Writer Writer
+// @param writer *std.Io.Writer Writer
 // @param options Options Additional options
 // @signature in1:T >
 // @usage
@@ -30,10 +30,10 @@ pub fn JSONStreamSink(comptime T: type) type {
         pub const Options = struct {};
 
         block: Block,
-        writer: *std.io.Writer,
+        writer: *std.Io.Writer,
         options: Options,
 
-        pub fn init(writer: *std.io.Writer, options: Options) Self {
+        pub fn init(writer: *std.Io.Writer, options: Options) Self {
             return .{ .block = Block.init(@This()), .writer = writer, .options = options };
         }
 
@@ -56,7 +56,7 @@ const BlockFixture = @import("../../radio.zig").testing.BlockFixture;
 
 test "JSONStreamSink" {
     var buf: [128]u8 = undefined;
-    var writer = std.io.Writer.fixed(&buf);
+    var writer = std.Io.Writer.fixed(&buf);
 
     const Foo = struct {
         a: u32,
@@ -81,7 +81,7 @@ test "JSONStreamSink" {
 
     try std.testing.expectEqualSlices(u8, output_json, writer.buffered());
 
-    writer = std.io.Writer.fixed(&buf);
+    writer = std.Io.Writer.fixed(&buf);
 
     // Test sample by sample
     for (input_samples) |sample| {

--- a/src/blocks/sinks/realstream.zig
+++ b/src/blocks/sinks/realstream.zig
@@ -2,7 +2,7 @@
 // @description Sink a real-valued signal to a binary stream, using the
 // specified sample format.
 // @category Sinks
-// @param writer *std.io.Writer Writer
+// @param writer *std.Io.Writer Writer
 // @param format SampleFormat Choice of s8, u8, u16le, u16be, s16le, s16be, u32le, u32be, s32le, s32be, f32le, f32be, f64le, f64be
 // @param options Options Additional options
 // @signature in1:f32 >
@@ -31,13 +31,13 @@ pub const RealStreamSink = struct {
     pub const Options = struct {};
 
     block: Block,
-    writer: *std.io.Writer,
+    writer: *std.Io.Writer,
     options: Options,
 
     converter: SampleFormat.Converter,
     buffer: [16384]u8 = undefined,
 
-    pub fn init(writer: *std.io.Writer, format: SampleFormat, options: Options) Self {
+    pub fn init(writer: *std.Io.Writer, format: SampleFormat, options: Options) Self {
         return .{ .block = Block.init(@This()), .writer = writer, .options = options, .converter = format.converter() };
     }
 
@@ -67,7 +67,7 @@ const vectors = @import("../../vectors/utils/sample_format.zig");
 
 test "RealStreamSink" {
     var buf: [64]u8 = undefined;
-    var writer = std.io.Writer.fixed(&buf);
+    var writer = std.Io.Writer.fixed(&buf);
 
     // Basic test
     var block = RealStreamSink.init(&writer, .u16be, .{});
@@ -79,7 +79,7 @@ test "RealStreamSink" {
 
     try std.testing.expectEqualSlices(u8, &vectors.bytes_real_u16be, writer.buffered());
 
-    writer = std.io.Writer.fixed(&buf);
+    writer = std.Io.Writer.fixed(&buf);
 
     // Test sample by sample
     for (vectors.input_real_samples) |sample| {

--- a/src/blocks/sinks/wavfile.zig
+++ b/src/blocks/sinks/wavfile.zig
@@ -65,17 +65,19 @@ pub fn WAVFileSink(comptime N: comptime_int) type {
         };
 
         block: Block,
-        file: *std.fs.File,
+        io: std.Io,
+        file: *std.Io.File,
         options: Options,
         converter: SampleFormat.Converter,
 
-        writer: std.fs.File.Writer = undefined,
+        writer: std.Io.File.Writer = undefined,
         writer_buffer: [16384]u8 = undefined,
         samples_written: usize = 0,
 
-        pub fn init(file: *std.fs.File, options: Options) Self {
+        pub fn init(io: std.Io, file: *std.Io.File, options: Options) Self {
             return .{
                 .block = Block.init(@This()),
+                .io = io,
                 .file = file,
                 .options = options,
                 .converter = switch (options.format) {
@@ -87,7 +89,7 @@ pub fn WAVFileSink(comptime N: comptime_int) type {
         }
 
         pub fn initialize(self: *Self, _: std.mem.Allocator) !void {
-            self.writer = self.file.writer(&self.writer_buffer);
+            self.writer = self.file.writer(self.io, &self.writer_buffer);
             self.samples_written = 0;
 
             // Seek past WAV headers (populated on cleanup)
@@ -197,15 +199,19 @@ const TemporaryFile = @import("../../radio.zig").testing.TemporaryFile;
 const vectors = @import("../../vectors/blocks/sources/wavfile.zig");
 
 test "WAVFileSink" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
     // Create temporary file
-    var tmpfile = try TemporaryFile.create();
+    var tmpfile = try TemporaryFile.create(io);
     defer tmpfile.close();
 
     // u8, 1 channel
     {
         try tmpfile.write(&.{});
 
-        var block = WAVFileSink(1).init(&tmpfile.file, .{ .format = .u8 });
+        var block = WAVFileSink(1).init(io, &tmpfile.file, .{ .format = .u8 });
         var fixture = try BlockFixture(&[1]type{f32}, &[0]type{}).init(&block.block, 44100);
         _ = try fixture.process(.{&vectors.samples_ch0});
         fixture.deinit();
@@ -219,7 +225,7 @@ test "WAVFileSink" {
     {
         try tmpfile.write(&.{});
 
-        var block = WAVFileSink(1).init(&tmpfile.file, .{ .format = .s16 });
+        var block = WAVFileSink(1).init(io, &tmpfile.file, .{ .format = .s16 });
         var fixture = try BlockFixture(&[1]type{f32}, &[0]type{}).init(&block.block, 44100);
         _ = try fixture.process(.{&vectors.samples_ch0});
         fixture.deinit();
@@ -233,7 +239,7 @@ test "WAVFileSink" {
     {
         try tmpfile.write(&.{});
 
-        var block = WAVFileSink(1).init(&tmpfile.file, .{ .format = .s32 });
+        var block = WAVFileSink(1).init(io, &tmpfile.file, .{ .format = .s32 });
         var fixture = try BlockFixture(&[1]type{f32}, &[0]type{}).init(&block.block, 44100);
         _ = try fixture.process(.{&vectors.samples_ch0});
         fixture.deinit();
@@ -247,7 +253,7 @@ test "WAVFileSink" {
     {
         try tmpfile.write(&.{});
 
-        var block = WAVFileSink(2).init(&tmpfile.file, .{ .format = .u8 });
+        var block = WAVFileSink(2).init(io, &tmpfile.file, .{ .format = .u8 });
         var fixture = try BlockFixture(&[2]type{ f32, f32 }, &[0]type{}).init(&block.block, 44100);
         _ = try fixture.process(.{ &vectors.samples_ch0, &vectors.samples_ch1 });
         fixture.deinit();
@@ -261,7 +267,7 @@ test "WAVFileSink" {
     {
         try tmpfile.write(&.{});
 
-        var block = WAVFileSink(2).init(&tmpfile.file, .{ .format = .s16 });
+        var block = WAVFileSink(2).init(io, &tmpfile.file, .{ .format = .s16 });
         var fixture = try BlockFixture(&[2]type{ f32, f32 }, &[0]type{}).init(&block.block, 44100);
         _ = try fixture.process(.{ &vectors.samples_ch0, &vectors.samples_ch1 });
         fixture.deinit();
@@ -275,7 +281,7 @@ test "WAVFileSink" {
     {
         try tmpfile.write(&.{});
 
-        var block = WAVFileSink(2).init(&tmpfile.file, .{ .format = .s32 });
+        var block = WAVFileSink(2).init(io, &tmpfile.file, .{ .format = .s32 });
         var fixture = try BlockFixture(&[2]type{ f32, f32 }, &[0]type{}).init(&block.block, 44100);
         _ = try fixture.process(.{ &vectors.samples_ch0, &vectors.samples_ch1 });
         fixture.deinit();

--- a/src/blocks/sources/application.zig
+++ b/src/blocks/sources/application.zig
@@ -41,6 +41,7 @@
 // try src.push(std.math.Complex(f32).init(2, 3));
 
 const std = @import("std");
+const sync = @import("../../core/sync.zig");
 
 const Block = @import("../../radio.zig").Block;
 const SampleMux = @import("../../core/sample_mux.zig").SampleMux;
@@ -253,7 +254,7 @@ test "ApplicationSource blocking wait" {
     try std.testing.expectError(error.Timeout, application_source.wait(2, std.time.ns_per_ms));
 
     const BufferWaiter = struct {
-        fn run(source: *ApplicationSource(u32), done: *std.Thread.ResetEvent) !void {
+        fn run(source: *ApplicationSource(u32), done: *sync.ResetEvent) !void {
             // Wait for two samples availability
             try source.wait(2, null);
             // Signal done
@@ -262,7 +263,7 @@ test "ApplicationSource blocking wait" {
     };
 
     // Spawn a thread that blocks until two samples are available
-    var done_event = std.Thread.ResetEvent{};
+    var done_event = sync.ResetEvent{};
     var thread = try std.Thread.spawn(.{}, BufferWaiter.run, .{ &application_source, &done_event });
 
     // Check thread is blocking

--- a/src/blocks/sources/iqstream.zig
+++ b/src/blocks/sources/iqstream.zig
@@ -2,7 +2,7 @@
 // @description Source a complex-valued signal from a binary stream, using the
 // specified sample format.
 // @category Sources
-// @param reader *std.io.Reader Reader
+// @param reader *std.Io.Reader Reader
 // @param format SampleFormat Choice of s8, u8, u16le, u16be, s16le, s16be, u32le, u32be, s32le, s32be, f32le, f32be, f64le, f64be
 // @param rate f64 Sample rate in Hz
 // @param options Options Additional options
@@ -32,7 +32,7 @@ pub const IQStreamSource = struct {
     pub const Options = struct {};
 
     block: Block,
-    reader: *std.io.Reader,
+    reader: *std.Io.Reader,
     rate: f64,
     options: Options,
 
@@ -40,7 +40,7 @@ pub const IQStreamSource = struct {
     buffer: [16384]u8 = undefined,
     offset: usize = 0,
 
-    pub fn init(reader: *std.io.Reader, format: SampleFormat, rate: f64, options: Options) Self {
+    pub fn init(reader: *std.Io.Reader, format: SampleFormat, rate: f64, options: Options) Self {
         return .{ .block = Block.init(@This()), .reader = reader, .rate = rate, .options = options, .converter = format.converter() };
     }
 
@@ -84,14 +84,14 @@ test "IQStreamSource" {
     // Teardown test hook to reset fbs reader between runs
     const hooks = struct {
         fn teardown(context: *anyopaque) !void {
-            var reader: *std.io.Reader = @ptrCast(@alignCast(context));
+            var reader: *std.Io.Reader = @ptrCast(@alignCast(context));
             reader.seek = 0;
         }
     };
 
     // Basic test
     {
-        var reader = std.io.Reader.fixed(&vectors.bytes_complex_u16be);
+        var reader = std.Io.Reader.fixed(&vectors.bytes_complex_u16be);
         var block = IQStreamSource.init(&reader, .u16be, 8000, .{});
         var tester = try BlockTester(&[0]type{}, &[1]type{std.math.Complex(f32)}).init(&block.block, 1e-6);
         try tester.checkSource(.{&vectors.samples_complex_u16be}, .{ .context = &reader, .teardown = hooks.teardown });
@@ -99,7 +99,7 @@ test "IQStreamSource" {
 
     // Test cut-off stream
     {
-        var reader = std.io.Reader.fixed(vectors.bytes_complex_u16be[0 .. vectors.bytes_complex_u16be.len - 1]);
+        var reader = std.Io.Reader.fixed(vectors.bytes_complex_u16be[0 .. vectors.bytes_complex_u16be.len - 1]);
         var block = IQStreamSource.init(&reader, .u16be, 8000, .{});
         var tester = try BlockTester(&[0]type{}, &[1]type{std.math.Complex(f32)}).init(&block.block, 1e-6);
         try tester.checkSource(.{vectors.samples_complex_u16be[0 .. vectors.samples_complex_u16be.len - 1]}, .{ .context = &reader, .teardown = hooks.teardown });

--- a/src/blocks/sources/realstream.zig
+++ b/src/blocks/sources/realstream.zig
@@ -2,7 +2,7 @@
 // @description Source a real-valued signal from a binary stream, using the
 // specified sample format.
 // @category Sources
-// @param reader std.io.AnyReader Reader
+// @param reader std.Io.AnyReader Reader
 // @param format SampleFormat Choice of s8, u8, u16le, u16be, s16le, s16be, u32le, u32be, s32le, s32be, f32le, f32be, f64le, f64be
 // @param rate f64 Sample rate in Hz
 // @param options Options Additional options
@@ -32,7 +32,7 @@ pub const RealStreamSource = struct {
     pub const Options = struct {};
 
     block: Block,
-    reader: *std.io.Reader,
+    reader: *std.Io.Reader,
     rate: f64,
     options: Options,
 
@@ -40,7 +40,7 @@ pub const RealStreamSource = struct {
     buffer: [16384]u8 = undefined,
     offset: usize = 0,
 
-    pub fn init(reader: *std.io.Reader, format: SampleFormat, rate: f64, options: Options) Self {
+    pub fn init(reader: *std.Io.Reader, format: SampleFormat, rate: f64, options: Options) Self {
         return .{ .block = Block.init(@This()), .reader = reader, .rate = rate, .options = options, .converter = format.converter() };
     }
 
@@ -84,14 +84,14 @@ test "RealStreamSource" {
     // Teardown test hook to reset fbs reader between runs
     const hooks = struct {
         fn teardown(context: *anyopaque) !void {
-            var reader: *std.io.Reader = @ptrCast(@alignCast(context));
+            var reader: *std.Io.Reader = @ptrCast(@alignCast(context));
             reader.seek = 0;
         }
     };
 
     // Basic test
     {
-        var reader = std.io.Reader.fixed(&vectors.bytes_real_u16be);
+        var reader = std.Io.Reader.fixed(&vectors.bytes_real_u16be);
         var block = RealStreamSource.init(&reader, .u16be, 8000, .{});
         var tester = try BlockTester(&[0]type{}, &[1]type{f32}).init(&block.block, 1e-6);
         try tester.checkSource(.{&vectors.samples_real_u16be}, .{ .context = &reader, .teardown = hooks.teardown });
@@ -99,7 +99,7 @@ test "RealStreamSource" {
 
     // Test cut-off stream
     {
-        var reader = std.io.Reader.fixed(vectors.bytes_real_u16be[0 .. vectors.bytes_real_u16be.len - 1]);
+        var reader = std.Io.Reader.fixed(vectors.bytes_real_u16be[0 .. vectors.bytes_real_u16be.len - 1]);
         var block = RealStreamSource.init(&reader, .u16be, 8000, .{});
         var tester = try BlockTester(&[0]type{}, &[1]type{f32}).init(&block.block, 1e-6);
         try tester.checkSource(.{vectors.samples_real_u16be[0 .. vectors.samples_real_u16be.len - 1]}, .{ .context = &reader, .teardown = hooks.teardown });

--- a/src/blocks/sources/wavfile.zig
+++ b/src/blocks/sources/wavfile.zig
@@ -67,20 +67,21 @@ pub fn WAVFileSource(comptime N: comptime_int) type {
         };
 
         block: Block,
-        file: *std.fs.File,
+        io: std.Io,
+        file: *std.Io.File,
         options: Options,
 
         rate: u32 = 0,
-        reader: std.fs.File.Reader = undefined,
+        reader: std.Io.File.Reader = undefined,
         reader_buffer: [16384]u8 = undefined,
         converter: SampleFormat.Converter = undefined,
 
-        pub fn init(file: *std.fs.File, options: Options) Self {
-            return .{ .block = Block.init(@This()), .file = file, .options = options };
+        pub fn init(io: std.Io, file: *std.Io.File, options: Options) Self {
+            return .{ .block = Block.init(@This()), .io = io, .file = file, .options = options };
         }
 
         pub fn initialize(self: *Self, _: std.mem.Allocator) !void {
-            self.reader = self.file.reader(&self.reader_buffer);
+            self.reader = self.file.reader(self.io, &self.reader_buffer);
 
             // Read headers
             const riff_header = try self.reader.interface.takeStruct(RiffHeader, .little);
@@ -179,14 +180,18 @@ const expectEqualVectors = @import("../../radio.zig").testing.expectEqualVectors
 const vectors = @import("../../vectors/blocks/sources/wavfile.zig");
 
 test "WAVFileSource" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
     // Create temporary file
-    var tmpfile = try TemporaryFile.create();
+    var tmpfile = try TemporaryFile.create(io);
     defer tmpfile.close();
 
     // u8, 1 channel
     {
         try tmpfile.write(&vectors.bytes_wavfile_u8_1ch);
-        var block = WAVFileSource(1).init(&tmpfile.file, .{});
+        var block = WAVFileSource(1).init(io, &tmpfile.file, .{});
         var tester = try BlockTester(&[0]type{}, &[1]type{f32}).init(&block.block, 1e-6);
         try tester.checkSource(.{&vectors.samples_u8_ch0}, .{});
     }
@@ -194,7 +199,7 @@ test "WAVFileSource" {
     // s16, 1 channel
     {
         try tmpfile.write(&vectors.bytes_wavfile_s16_1ch);
-        var block = WAVFileSource(1).init(&tmpfile.file, .{});
+        var block = WAVFileSource(1).init(io, &tmpfile.file, .{});
         var tester = try BlockTester(&[0]type{}, &[1]type{f32}).init(&block.block, 1e-6);
         try tester.checkSource(.{&vectors.samples_s16_ch0}, .{});
     }
@@ -202,7 +207,7 @@ test "WAVFileSource" {
     // s32, 1 channel
     {
         try tmpfile.write(&vectors.bytes_wavfile_s32_1ch);
-        var block = WAVFileSource(1).init(&tmpfile.file, .{});
+        var block = WAVFileSource(1).init(io, &tmpfile.file, .{});
         var tester = try BlockTester(&[0]type{}, &[1]type{f32}).init(&block.block, 1e-6);
         try tester.checkSource(.{&vectors.samples_s32_ch0}, .{});
     }
@@ -210,7 +215,7 @@ test "WAVFileSource" {
     // u8, 2 channel
     {
         try tmpfile.write(&vectors.bytes_wavfile_u8_2ch);
-        var block = WAVFileSource(2).init(&tmpfile.file, .{});
+        var block = WAVFileSource(2).init(io, &tmpfile.file, .{});
         var tester = try BlockTester(&[0]type{}, &[2]type{ f32, f32 }).init(&block.block, 1e-6);
         try tester.checkSource(.{ &vectors.samples_u8_ch0, &vectors.samples_u8_ch1 }, .{});
     }
@@ -218,7 +223,7 @@ test "WAVFileSource" {
     // s16, 2 channel
     {
         try tmpfile.write(&vectors.bytes_wavfile_s16_2ch);
-        var block = WAVFileSource(2).init(&tmpfile.file, .{});
+        var block = WAVFileSource(2).init(io, &tmpfile.file, .{});
         var tester = try BlockTester(&[0]type{}, &[2]type{ f32, f32 }).init(&block.block, 1e-6);
         try tester.checkSource(.{ &vectors.samples_s16_ch0, &vectors.samples_s16_ch1 }, .{});
     }
@@ -226,7 +231,7 @@ test "WAVFileSource" {
     // s32, 2 channel
     {
         try tmpfile.write(&vectors.bytes_wavfile_s32_2ch);
-        var block = WAVFileSource(2).init(&tmpfile.file, .{});
+        var block = WAVFileSource(2).init(io, &tmpfile.file, .{});
         var tester = try BlockTester(&[0]type{}, &[2]type{ f32, f32 }).init(&block.block, 1e-6);
         try tester.checkSource(.{ &vectors.samples_s32_ch0, &vectors.samples_s32_ch1 }, .{});
     }
@@ -234,7 +239,7 @@ test "WAVFileSource" {
     // s16, 1 channel, repeat on eof
     {
         try tmpfile.write(&vectors.bytes_wavfile_s16_1ch);
-        var block = WAVFileSource(1).init(&tmpfile.file, .{ .repeat_on_eof = true });
+        var block = WAVFileSource(1).init(io, &tmpfile.file, .{ .repeat_on_eof = true });
         var fixture = try BlockFixture(&[0]type{}, &[1]type{f32}).init(&block.block, 0);
         defer fixture.deinit();
 
@@ -248,7 +253,7 @@ test "WAVFileSource" {
     // s16, 2 channel, repeat on eof
     {
         try tmpfile.write(&vectors.bytes_wavfile_s16_2ch);
-        var block = WAVFileSource(2).init(&tmpfile.file, .{ .repeat_on_eof = true });
+        var block = WAVFileSource(2).init(io, &tmpfile.file, .{ .repeat_on_eof = true });
         var fixture = try BlockFixture(&[0]type{}, &[2]type{ f32, f32 }).init(&block.block, 0);
         defer fixture.deinit();
 
@@ -266,7 +271,7 @@ test "WAVFileSource" {
         var buf = vectors.bytes_wavfile_u8_1ch;
         buf[0] = 'A';
         try tmpfile.write(&buf);
-        var block = WAVFileSource(1).init(&tmpfile.file, .{});
+        var block = WAVFileSource(1).init(io, &tmpfile.file, .{});
         try std.testing.expectError(error.InvalidHeader, block.initialize(std.testing.allocator));
     }
 
@@ -275,7 +280,7 @@ test "WAVFileSource" {
         var buf = vectors.bytes_wavfile_u8_1ch;
         buf[8] = 'A';
         try tmpfile.write(&buf);
-        var block = WAVFileSource(1).init(&tmpfile.file, .{});
+        var block = WAVFileSource(1).init(io, &tmpfile.file, .{});
         try std.testing.expectError(error.InvalidHeader, block.initialize(std.testing.allocator));
     }
 
@@ -284,7 +289,7 @@ test "WAVFileSource" {
         var buf = vectors.bytes_wavfile_u8_1ch;
         buf[@sizeOf(RiffHeader)] = 'A';
         try tmpfile.write(&buf);
-        var block = WAVFileSource(1).init(&tmpfile.file, .{});
+        var block = WAVFileSource(1).init(io, &tmpfile.file, .{});
         try std.testing.expectError(error.InvalidHeader, block.initialize(std.testing.allocator));
     }
 
@@ -293,7 +298,7 @@ test "WAVFileSource" {
         var buf = vectors.bytes_wavfile_u8_1ch;
         buf[@sizeOf(RiffHeader) + @sizeOf(WaveSubchunk1Header)] = 'A';
         try tmpfile.write(&buf);
-        var block = WAVFileSource(1).init(&tmpfile.file, .{});
+        var block = WAVFileSource(1).init(io, &tmpfile.file, .{});
         try std.testing.expectError(error.InvalidHeader, block.initialize(std.testing.allocator));
     }
 
@@ -302,7 +307,7 @@ test "WAVFileSource" {
         var buf = vectors.bytes_wavfile_u8_1ch;
         buf[@sizeOf(RiffHeader) + 8] = 2;
         try tmpfile.write(&buf);
-        var block = WAVFileSource(1).init(&tmpfile.file, .{});
+        var block = WAVFileSource(1).init(io, &tmpfile.file, .{});
         try std.testing.expectError(error.UnsupportedAudioFormat, block.initialize(std.testing.allocator));
     }
 
@@ -311,14 +316,14 @@ test "WAVFileSource" {
         var buf = vectors.bytes_wavfile_u8_1ch;
         buf[@sizeOf(RiffHeader) + 22] = 64;
         try tmpfile.write(&buf);
-        var block = WAVFileSource(1).init(&tmpfile.file, .{});
+        var block = WAVFileSource(1).init(io, &tmpfile.file, .{});
         try std.testing.expectError(error.UnsupportedBitsPerSample, block.initialize(std.testing.allocator));
     }
 
     // Num channels mismatch
     {
         try tmpfile.write(&vectors.bytes_wavfile_u8_2ch);
-        var block = WAVFileSource(1).init(&tmpfile.file, .{});
+        var block = WAVFileSource(1).init(io, &tmpfile.file, .{});
         try std.testing.expectError(error.NumChannelsMismatch, block.initialize(std.testing.allocator));
     }
 }

--- a/src/core/block.zig
+++ b/src/core/block.zig
@@ -143,7 +143,7 @@ pub const Block = struct {
         }
 
         // Derive type signature from process method
-        const type_signature = ComptimeTypeSignature.init(BlockType.process);
+        const type_signature = comptime ComptimeTypeSignature.init(BlockType.process);
         if (type_signature.inputs.len == 0 and !@hasDecl(BlockType, "setRate")) {
             @compileError("Source block " ++ @typeName(BlockType) ++ " is missing the setRate() method.");
         }

--- a/src/core/block.zig
+++ b/src/core/block.zig
@@ -196,14 +196,14 @@ pub const Block = struct {
     // Raw Block Constructor
     ////////////////////////////////////////////////////////////////////////////
 
-    pub fn initRaw(comptime BlockType: type, input_data_types: []const type, output_data_types: []const type) Block {
+    pub fn initRaw(comptime BlockType: type, comptime input_data_types: []const type, comptime output_data_types: []const type) Block {
         // Raw block needs to have a start method
         if (!@hasDecl(BlockType, "start")) {
             @compileError("Block " ++ @typeName(BlockType) ++ " is missing the start() method.");
         }
 
         // Construct type signature
-        const type_signature = ComptimeTypeSignature.fromTypes(input_data_types, output_data_types);
+        const type_signature = comptime ComptimeTypeSignature.fromTypes(input_data_types, output_data_types);
         if (type_signature.inputs.len == 0 and !@hasDecl(BlockType, "setRate")) {
             @compileError("Source block " ++ @typeName(BlockType) ++ " is missing the setRate() method.");
         }
@@ -409,7 +409,7 @@ test "Block.process" {
 
     var test_block = TestAddBlock.init();
 
-    const ts = ComptimeTypeSignature.init(TestAddBlock.process);
+    const ts = comptime ComptimeTypeSignature.init(TestAddBlock.process);
 
     var test_sample_mux = try TestSampleMux(ts.inputs, ts.outputs).init([2][]const u8{ ibuf1[0..], ibuf2[0..] }, .{});
     defer test_sample_mux.deinit();
@@ -427,7 +427,7 @@ test "Block.process" {
 test "Block.process eos" {
     var test_source = TestSource.init();
 
-    const ts = ComptimeTypeSignature.init(TestSource.process);
+    const ts = comptime ComptimeTypeSignature.init(TestSource.process);
 
     var test_sample_mux = try TestSampleMux(ts.inputs, ts.outputs).init([0][]const u8{}, .{});
     defer test_sample_mux.deinit();

--- a/src/core/flowgraph.zig
+++ b/src/core/flowgraph.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const sync = @import("sync.zig");
 
 const util = @import("util.zig");
 const platform = @import("platform.zig");
@@ -11,6 +12,56 @@ const ThreadSafeRingBuffer = @import("ring_buffer.zig").ThreadSafeRingBuffer;
 const ThreadSafeRingBufferSampleMux = @import("sample_mux.zig").ThreadSafeRingBufferSampleMux;
 const RawBlockRunner = @import("runner.zig").RawBlockRunner;
 const ThreadedBlockRunner = @import("runner.zig").ThreadedBlockRunner;
+
+////////////////////////////////////////////////////////////////////////////////
+// Managed AutoArrayHashMap (Zig 0.16 removed the managed variant from std)
+////////////////////////////////////////////////////////////////////////////////
+
+fn AutoArrayHashMap(comptime K: type, comptime V: type) type {
+    return struct {
+        const Self = @This();
+        const Unmanaged = std.AutoArrayHashMapUnmanaged(K, V);
+
+        unmanaged: Unmanaged = .{},
+        allocator: std.mem.Allocator,
+
+        pub fn init(allocator: std.mem.Allocator) Self {
+            return .{ .allocator = allocator };
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.unmanaged.deinit(self.allocator);
+        }
+
+        pub fn put(self: *Self, key: K, value: V) !void {
+            return self.unmanaged.put(self.allocator, key, value);
+        }
+
+        pub fn get(self: Self, key: K) ?V {
+            return self.unmanaged.get(key);
+        }
+
+        pub fn getPtr(self: Self, key: K) ?*V {
+            return self.unmanaged.getPtr(key);
+        }
+
+        pub fn contains(self: Self, key: K) bool {
+            return self.unmanaged.contains(key);
+        }
+
+        pub fn count(self: Self) usize {
+            return self.unmanaged.count();
+        }
+
+        pub fn keys(self: Self) []K {
+            return self.unmanaged.keys();
+        }
+
+        pub fn values(self: Self) []V {
+            return self.unmanaged.values();
+        }
+    };
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Flowgraph Errors
@@ -67,11 +118,11 @@ const BlockOutputPort = struct {
 // Helper Functions
 ////////////////////////////////////////////////////////////////////////////////
 
-fn buildEvaluationOrder(allocator: std.mem.Allocator, flattened_connections: *const std.AutoHashMap(BlockInputPort, BlockOutputPort), block_set: *const std.AutoHashMap(*Block, void)) !std.AutoArrayHashMap(*Block, void) {
+fn buildEvaluationOrder(allocator: std.mem.Allocator, flattened_connections: *const std.AutoHashMap(BlockInputPort, BlockOutputPort), block_set: *const std.AutoHashMap(*Block, void)) !AutoArrayHashMap(*Block, void) {
     var block_set_copy = try block_set.cloneWithAllocator(allocator);
     defer block_set_copy.deinit();
 
-    var evaluation_order = std.AutoArrayHashMap(*Block, void).init(allocator);
+    var evaluation_order = AutoArrayHashMap(*Block, void).init(allocator);
     errdefer evaluation_order.deinit();
 
     const num_blocks = block_set_copy.count();
@@ -111,8 +162,8 @@ const FlowgraphRunState = struct {
     const BlockRunner = union(enum) { raw: RawBlockRunner, threaded: ThreadedBlockRunner };
 
     ring_buffers: std.AutoHashMap(BlockOutputPort, ThreadSafeRingBuffer),
-    sample_muxes: std.AutoArrayHashMap(*Block, ThreadSafeRingBufferSampleMux),
-    block_runners: std.AutoArrayHashMap(*Block, BlockRunner),
+    sample_muxes: AutoArrayHashMap(*Block, ThreadSafeRingBufferSampleMux),
+    block_runners: AutoArrayHashMap(*Block, BlockRunner),
 
     const RING_BUFFER_SIZE = 8 * 1048576;
 
@@ -126,14 +177,14 @@ const FlowgraphRunState = struct {
         }
 
         // Allocate sample mux map
-        var sample_muxes = std.AutoArrayHashMap(*Block, ThreadSafeRingBufferSampleMux).init(allocator);
+        var sample_muxes = AutoArrayHashMap(*Block, ThreadSafeRingBufferSampleMux).init(allocator);
         errdefer {
             for (sample_muxes.values()) |*sample_mux| sample_mux.deinit();
             sample_muxes.deinit();
         }
 
         // Allocate block runner map
-        var block_runners = std.AutoArrayHashMap(*Block, BlockRunner).init(allocator);
+        var block_runners = AutoArrayHashMap(*Block, BlockRunner).init(allocator);
         errdefer {
             for (block_runners.values()) |*block_runner| switch (block_runner.*) {
                 inline else => |*r| r.deinit(),
@@ -382,7 +433,7 @@ pub const Flowgraph = struct {
         }
     }
 
-    pub fn _propagateRates(self: *Flowgraph, evaluation_order: *const std.AutoArrayHashMap(*Block, void)) !void {
+    pub fn _propagateRates(self: *Flowgraph, evaluation_order: *const AutoArrayHashMap(*Block, void)) !void {
         // For each block in the evaluation order
         for (evaluation_order.keys()) |block| {
             // Get upstream rate
@@ -431,7 +482,7 @@ pub const Flowgraph = struct {
         }
     }
 
-    fn _dump(self: *Flowgraph, evaluation_order: *std.AutoArrayHashMap(*Block, void)) void {
+    fn _dump(self: *Flowgraph, evaluation_order: *AutoArrayHashMap(*Block, void)) void {
         std.debug.print("[Flowgraph] Flowgraph:\n", .{});
 
         // For each block in the evaluation order
@@ -1581,7 +1632,7 @@ test "Flowgraph start, stop" {
     try top.start();
 
     // Run for 1 ms
-    std.Thread.sleep(std.time.ns_per_ms);
+    sync.sleep(std.time.ns_per_ms);
 
     // Stop flow graph and check for success
     try std.testing.expectEqual(true, try top.stop());

--- a/src/core/flowgraph.zig
+++ b/src/core/flowgraph.zig
@@ -45,6 +45,10 @@ fn AutoArrayHashMap(comptime K: type, comptime V: type) type {
             return self.unmanaged.getPtr(key);
         }
 
+        pub fn getIndex(self: Self, key: K) ?usize {
+            return self.unmanaged.getIndex(key);
+        }
+
         pub fn contains(self: Self, key: K) bool {
             return self.unmanaged.contains(key);
         }

--- a/src/core/platform.zig
+++ b/src/core/platform.zig
@@ -28,13 +28,9 @@ fn isTruthy(value: []const u8) bool {
     return false;
 }
 
-fn lookupEnvFlag(allocator: std.mem.Allocator, key: []const u8) !bool {
-    if (std.process.getEnvVarOwned(allocator, key)) |env_var| {
-        defer allocator.free(env_var);
-        return isTruthy(env_var);
-    } else |_| {
-        return false;
-    }
+fn lookupEnvFlag(_: std.mem.Allocator, key: [:0]const u8) !bool {
+    const env_var = std.c.getenv(key.ptr) orelse return false;
+    return isTruthy(std.mem.span(env_var));
 }
 
 pub fn initialize(allocator: std.mem.Allocator) !void {

--- a/src/core/ring_buffer.zig
+++ b/src/core/ring_buffer.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const sync = @import("sync.zig");
 
 ////////////////////////////////////////////////////////////////////////////////
 // RingBuffer Memory Implementations
@@ -40,17 +41,17 @@ const MappedMemoryImpl = struct {
     pub fn init(_: std.mem.Allocator, capacity: usize) !MappedMemoryImpl {
         // Create memfd
         const fd = try std.posix.memfd_create("ring_buffer_mem", 0);
-        errdefer std.posix.close(fd);
+        errdefer _ = std.c.close(fd);
 
         // Size memory
-        try std.posix.ftruncate(fd, capacity);
+        if (std.c.ftruncate(fd, @intCast(capacity)) != 0) return error.Ftruncate;
 
         // Map the file with two regions of capacity
-        const mapping1 = try std.posix.mmap(null, 2 * capacity, std.posix.PROT.READ | std.posix.PROT.WRITE, .{ .TYPE = .SHARED }, fd, 0);
+        const mapping1 = try std.posix.mmap(null, 2 * capacity, .{ .READ = true, .WRITE = true }, .{ .TYPE = .SHARED }, fd, 0);
         errdefer std.posix.munmap(mapping1);
 
         // Remap second region to first
-        const mapping2 = try std.posix.mmap(@alignCast(mapping1.ptr + capacity), capacity, std.posix.PROT.READ | std.posix.PROT.WRITE, .{ .TYPE = .SHARED, .FIXED = true }, fd, 0);
+        const mapping2 = try std.posix.mmap(@alignCast(mapping1.ptr + capacity), capacity, .{ .READ = true, .WRITE = true }, .{ .TYPE = .SHARED, .FIXED = true }, fd, 0);
         errdefer std.posix.munmap(mapping2);
 
         // Validate mapping is adjacent
@@ -63,7 +64,7 @@ const MappedMemoryImpl = struct {
 
     pub fn deinit(self: *MappedMemoryImpl) void {
         std.posix.munmap(self.buf);
-        std.posix.close(self.fd);
+        _ = std.c.close(self.fd);
     }
 
     pub fn alias(_: *MappedMemoryImpl, _: usize, _: usize, _: usize) void {
@@ -262,9 +263,9 @@ fn _ThreadSafeRingBuffer(comptime RingBufferImpl: type) type {
         impl: RingBufferImpl,
 
         // Lock and Condition Variables
-        mutex: std.Thread.Mutex = .{},
-        cond_read_available: std.Thread.Condition = .{},
-        cond_write_available: std.Thread.Condition = .{},
+        mutex: sync.Mutex = .{},
+        cond_read_available: sync.Condition = .{},
+        cond_write_available: sync.Condition = .{},
 
         ////////////////////////////////////////////////////////////////////////
         // Constructor and Destructor
@@ -702,7 +703,7 @@ test "ThreadSafeRingBuffer write wait" {
         try std.testing.expectError(error.Timeout, writer.waitAvailable(5, std.time.ns_per_ms));
 
         const WriteWaiter = struct {
-            fn run(wr: *ThreadSafeRingBufferType.Writer, done: *std.Thread.ResetEvent) !void {
+            fn run(wr: *ThreadSafeRingBufferType.Writer, done: *sync.ResetEvent) !void {
                 // Blocking wait for 7
                 _ = try wr.waitAvailable(7, null);
                 // Signal done
@@ -711,7 +712,7 @@ test "ThreadSafeRingBuffer write wait" {
         };
 
         // Spawn a thread that waits until writer has 7 available
-        var done_event = std.Thread.ResetEvent{};
+        var done_event = sync.ResetEvent{};
         var thread = try std.Thread.spawn(.{}, WriteWaiter.run, .{ &writer, &done_event });
 
         // Reader 1 read 1
@@ -762,7 +763,7 @@ test "ThreadSafeRingBuffer read wait" {
         try std.testing.expectError(error.Timeout, reader2.waitAvailable(8, std.time.ns_per_ms));
 
         const ReadWaiter = struct {
-            fn run(rd: *ThreadSafeRingBufferType.Reader, done: *std.Thread.ResetEvent) !void {
+            fn run(rd: *ThreadSafeRingBufferType.Reader, done: *sync.ResetEvent) !void {
                 // Wait for 5
                 _ = try rd.waitAvailable(5, null);
                 // Signal done
@@ -771,7 +772,7 @@ test "ThreadSafeRingBuffer read wait" {
         };
 
         // Spawn a thread that waits until reader has 7 available
-        var done_event = std.Thread.ResetEvent{};
+        var done_event = sync.ResetEvent{};
         var thread = try std.Thread.spawn(.{}, ReadWaiter.run, .{ &reader1, &done_event });
 
         // Reader 2 read 2
@@ -888,7 +889,7 @@ test "ThreadSafeRingBuffer read wait eos" {
         var reader = ring_buffer.reader();
 
         const ReadWaiter = struct {
-            fn run(rd: *ThreadSafeRingBufferType.Reader, done: *std.Thread.ResetEvent) !void {
+            fn run(rd: *ThreadSafeRingBufferType.Reader, done: *sync.ResetEvent) !void {
                 // Wait for 5
                 _ = rd.waitAvailable(5, null) catch 0;
                 // Signal done
@@ -897,7 +898,7 @@ test "ThreadSafeRingBuffer read wait eos" {
         };
 
         // Spawn a thread that waits until reader has available
-        var done_event = std.Thread.ResetEvent{};
+        var done_event = sync.ResetEvent{};
         var thread = try std.Thread.spawn(.{}, ReadWaiter.run, .{ &reader, &done_event });
 
         // Done event should not be set
@@ -932,7 +933,7 @@ test "ThreadSafeRingBuffer read wait eos with partial read" {
         var reader = ring_buffer.reader();
 
         const ReadWaiter = struct {
-            fn run(rd: *ThreadSafeRingBufferType.Reader, done: *std.Thread.ResetEvent) !void {
+            fn run(rd: *ThreadSafeRingBufferType.Reader, done: *sync.ResetEvent) !void {
                 // Wait for 5
                 _ = rd.waitAvailable(5, null) catch 0;
                 // Signal done
@@ -941,7 +942,7 @@ test "ThreadSafeRingBuffer read wait eos with partial read" {
         };
 
         // Spawn a thread that waits until reader has available
-        var done_event = std.Thread.ResetEvent{};
+        var done_event = sync.ResetEvent{};
         var thread = try std.Thread.spawn(.{}, ReadWaiter.run, .{ &reader, &done_event });
 
         // Done event should not be set
@@ -988,7 +989,7 @@ test "ThreadSafeRingBuffer write wait eos" {
         writer.update(7);
 
         const ReadWaiter = struct {
-            fn run(wr: *ThreadSafeRingBufferType.Writer, done: *std.Thread.ResetEvent) !void {
+            fn run(wr: *ThreadSafeRingBufferType.Writer, done: *sync.ResetEvent) !void {
                 // Wait for 1
                 _ = wr.waitAvailable(1, null) catch 0;
                 // Signal done
@@ -997,7 +998,7 @@ test "ThreadSafeRingBuffer write wait eos" {
         };
 
         // Spawn a thread that waits until reader has available
-        var done_event = std.Thread.ResetEvent{};
+        var done_event = sync.ResetEvent{};
         var thread = try std.Thread.spawn(.{}, ReadWaiter.run, .{ &writer, &done_event });
 
         // Done event should not be set

--- a/src/core/runner.zig
+++ b/src/core/runner.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const sync = @import("sync.zig");
 
 const Block = @import("block.zig").Block;
 const SampleMux = @import("sample_mux.zig").SampleMux;
@@ -62,9 +63,9 @@ pub const ThreadedBlockRunner = struct {
     process_error: ?anyerror = null,
 
     thread: std.Thread = undefined,
-    mutex: std.Thread.Mutex = .{},
-    call_event: std.Thread.ResetEvent = .{},
-    stop_event: std.Thread.ResetEvent = .{},
+    mutex: sync.Mutex = .{},
+    call_event: sync.ResetEvent = .{},
+    stop_event: sync.ResetEvent = .{},
 
     pub fn init(_: std.mem.Allocator, block: *Block, sample_mux: SampleMux) !ThreadedBlockRunner {
         return .{
@@ -88,7 +89,7 @@ pub const ThreadedBlockRunner = struct {
                         break;
                     } else if (runner.call_event.isSet()) {
                         // Give calling thread a chance to lock the mutex
-                        std.Thread.sleep(std.time.ns_per_us);
+                        sync.sleep(std.time.ns_per_us);
                     }
 
                     runner.mutex.lock();
@@ -445,7 +446,7 @@ test "ThreadedBlockRunner infinite run" {
     try test_sink_runner.spawn();
 
     // Run for 1ms
-    std.Thread.sleep(std.time.ns_per_ms);
+    sync.sleep(std.time.ns_per_ms);
 
     // Stop source runner
     test_source_runner.stop();
@@ -497,7 +498,7 @@ test "ThreadedBlockRunner block errors" {
     try test_sink_runner.spawn();
 
     // Run for 1ms
-    std.Thread.sleep(std.time.ns_per_ms);
+    sync.sleep(std.time.ns_per_ms);
 
     // Join block runners
     test_source_runner.join();

--- a/src/core/sample_mux.zig
+++ b/src/core/sample_mux.zig
@@ -402,7 +402,7 @@ test "TestSampleMux multiple input, single output" {
     const ibuf1: [8]u8 align(4) = .{ 0xaa, 0xbb, 0xcc, 0xdd, 0xab, 0xcd, 0xee, 0xff };
     const ibuf2: [8]u8 align(4) = .{ 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 };
 
-    const ts = ComptimeTypeSignature.fromTypes(&[2]type{ u32, u32 }, &[1]type{u16});
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[2]type{ u32, u32 }, &[1]type{u16});
 
     var test_sample_mux = try TestSampleMux(ts.inputs, ts.outputs).init([2][]const u8{ &ibuf1, &ibuf2 }, .{});
     defer test_sample_mux.deinit();
@@ -449,10 +449,10 @@ test "TestSampleMux multiple input, single output" {
 }
 
 test "TestSampleMux single input samples" {
-    const ibuf1: [8]u8 = .{ 0xaa, 0xbb, 0xcc, 0xdd, 0xab, 0xcd, 0xee, 0xff };
-    const ibuf2: [8]u8 = .{ 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 };
+    const ibuf1: [8]u8 align(4) = .{ 0xaa, 0xbb, 0xcc, 0xdd, 0xab, 0xcd, 0xee, 0xff };
+    const ibuf2: [8]u8 align(4) = .{ 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 };
 
-    const ts = ComptimeTypeSignature.fromTypes(&[2]type{ u32, u32 }, &[1]type{u16});
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[2]type{ u32, u32 }, &[1]type{u16});
 
     var test_sample_mux = try TestSampleMux(ts.inputs, ts.outputs).init([2][]const u8{ &ibuf1, &ibuf2 }, .{ .single_input_samples = true });
     defer test_sample_mux.deinit();
@@ -489,7 +489,7 @@ test "TestSampleMux single input samples" {
 }
 
 test "TestSampleMux single output samples" {
-    const ts = ComptimeTypeSignature.fromTypes(&[0]type{}, &[1]type{u32});
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[0]type{}, &[1]type{u32});
 
     var test_sample_mux = try TestSampleMux(ts.inputs, ts.outputs).init([0][]const u8{}, .{ .single_output_samples = true });
     defer test_sample_mux.deinit();
@@ -512,7 +512,7 @@ test "TestSampleMux single output samples" {
 }
 
 test "ThreadSafeRingBufferSampleMux single input, single output" {
-    const ts = ComptimeTypeSignature.fromTypes(&[1]type{u16}, &[1]type{u32});
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[1]type{u16}, &[1]type{u32});
 
     // Create ring buffers
     var input_ring_buffer = try ThreadSafeRingBuffer.init(std.testing.allocator, std.heap.page_size_min);
@@ -618,7 +618,7 @@ test "ThreadSafeRingBufferSampleMux single input, single output" {
 }
 
 test "ThreadSafeRingBufferSampleMux multiple input, multiple output" {
-    const ts = ComptimeTypeSignature.fromTypes(&[2]type{ u16, u8 }, &[2]type{ u32, u8 });
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[2]type{ u16, u8 }, &[2]type{ u32, u8 });
 
     // Create ring buffers
     var input1_ring_buffer = try ThreadSafeRingBuffer.init(std.testing.allocator, std.heap.page_size_min);
@@ -698,7 +698,7 @@ test "ThreadSafeRingBufferSampleMux multiple input, multiple output" {
 }
 
 test "ThreadSafeRingBufferSampleMux only inputs" {
-    const ts = ComptimeTypeSignature.fromTypes(&[2]type{ u16, u8 }, &[0]type{});
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[2]type{ u16, u8 }, &[0]type{});
 
     // Create ring buffers
     var input1_ring_buffer = try ThreadSafeRingBuffer.init(std.testing.allocator, std.heap.page_size_min);
@@ -764,7 +764,7 @@ test "ThreadSafeRingBufferSampleMux only inputs" {
 }
 
 test "ThreadSafeRingBufferSampleMux only outputs" {
-    const ts = ComptimeTypeSignature.fromTypes(&[0]type{}, &[2]type{ u32, u8 });
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[0]type{}, &[2]type{ u32, u8 });
 
     // Create ring buffers
     var output1_ring_buffer = try ThreadSafeRingBuffer.init(std.testing.allocator, std.heap.page_size_min);
@@ -817,7 +817,7 @@ test "ThreadSafeRingBufferSampleMux only outputs" {
 }
 
 test "ThreadSafeRingBufferSampleMux read eos" {
-    const ts = ComptimeTypeSignature.fromTypes(&[2]type{ u16, u8 }, &[1]type{u32});
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[2]type{ u16, u8 }, &[1]type{u32});
 
     // Create ring buffers
     var input1_ring_buffer = try ThreadSafeRingBuffer.init(std.testing.allocator, std.heap.page_size_min);
@@ -908,7 +908,7 @@ test "ThreadSafeRingBufferSampleMux read eos" {
 }
 
 test "ThreadSafeRingBufferSampleMux write eos" {
-    const ts = ComptimeTypeSignature.fromTypes(&[1]type{u16}, &[1]type{u32});
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[1]type{u16}, &[1]type{u32});
 
     // Create ring buffers
     var input_ring_buffer = try ThreadSafeRingBuffer.init(std.testing.allocator, std.heap.page_size_min);
@@ -967,7 +967,7 @@ test "ThreadSafeRingBufferSampleMux write eos" {
 }
 
 test "ThreadSafeRingBufferSampleMux broken stream" {
-    const ts = ComptimeTypeSignature.fromTypes(&[1]type{u16}, &[1]type{u32});
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[1]type{u16}, &[1]type{u32});
 
     // Create ring buffers
     var input_ring_buffer = try ThreadSafeRingBuffer.init(std.testing.allocator, std.heap.page_size_min);
@@ -999,7 +999,7 @@ test "ThreadSafeRingBufferSampleMux blocking read" {
         return error.SkipZigTest;
     }
 
-    const ts = ComptimeTypeSignature.fromTypes(&[2]type{ u16, u8 }, &[2]type{ u32, u8 });
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[2]type{ u16, u8 }, &[2]type{ u32, u8 });
 
     // Create ring buffers
     var input1_ring_buffer = try ThreadSafeRingBuffer.init(std.testing.allocator, std.heap.page_size_min);
@@ -1084,7 +1084,7 @@ test "ThreadSafeRingBufferSampleMux blocking write" {
         return error.SkipZigTest;
     }
 
-    const ts = ComptimeTypeSignature.fromTypes(&[2]type{ u16, u8 }, &[2]type{ u32, u8 });
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[2]type{ u16, u8 }, &[2]type{ u32, u8 });
 
     // Create ring buffers
     var input1_ring_buffer = try ThreadSafeRingBuffer.init(std.testing.allocator, std.heap.page_size_min);
@@ -1190,7 +1190,7 @@ const Foo = struct {
 };
 
 test "RefCounted output with no readers" {
-    const ts = ComptimeTypeSignature.fromTypes(&[0]type{}, &[1]type{RefCounted(Foo)});
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[0]type{}, &[1]type{RefCounted(Foo)});
 
     // Create ring buffers
     var output_ring_buffer = try ThreadSafeRingBuffer.init(std.testing.allocator, std.heap.page_size_min);
@@ -1225,7 +1225,7 @@ test "RefCounted output with no readers" {
 }
 
 test "RefCounted output with one reader" {
-    const ts = ComptimeTypeSignature.fromTypes(&[0]type{}, &[1]type{RefCounted(Foo)});
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[0]type{}, &[1]type{RefCounted(Foo)});
 
     // Create ring buffers
     var output_ring_buffer = try ThreadSafeRingBuffer.init(std.testing.allocator, std.heap.page_size_min);
@@ -1257,7 +1257,7 @@ test "RefCounted output with one reader" {
 }
 
 test "RefCounted output with two readers" {
-    const ts = ComptimeTypeSignature.fromTypes(&[0]type{}, &[1]type{RefCounted(Foo)});
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[0]type{}, &[1]type{RefCounted(Foo)});
 
     // Create ring buffers
     var output_ring_buffer = try ThreadSafeRingBuffer.init(std.testing.allocator, std.heap.page_size_min);
@@ -1290,7 +1290,7 @@ test "RefCounted output with two readers" {
 }
 
 test "RefCounted input" {
-    const ts = ComptimeTypeSignature.fromTypes(&[1]type{RefCounted(Foo)}, &[0]type{});
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[1]type{RefCounted(Foo)}, &[0]type{});
 
     // Create ring buffers
     var input_ring_buffer = try ThreadSafeRingBuffer.init(std.testing.allocator, std.heap.page_size_min);

--- a/src/core/sample_mux.zig
+++ b/src/core/sample_mux.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const sync = @import("sync.zig");
 
 const util = @import("util.zig");
 
@@ -1033,7 +1034,7 @@ test "ThreadSafeRingBufferSampleMux blocking read" {
     try std.testing.expectError(error.Timeout, sample_mux.wait(ts, std.time.ns_per_ms));
 
     const BufferWaiter = struct {
-        fn run(sm: *SampleMux, done: *std.Thread.ResetEvent, _buffers: *SampleMux.SampleBuffers(ts)) !void {
+        fn run(sm: *SampleMux, done: *sync.ResetEvent, _buffers: *SampleMux.SampleBuffers(ts)) !void {
             // Wait for update buffers
             _buffers.* = try sm.get(ts);
             // Signal done
@@ -1043,7 +1044,7 @@ test "ThreadSafeRingBufferSampleMux blocking read" {
 
     // Spawn a thread that blocks until sample buffers are available
     var buffers: SampleMux.SampleBuffers(ts) = undefined;
-    var done_event = std.Thread.ResetEvent{};
+    var done_event = sync.ResetEvent{};
     var thread = try std.Thread.spawn(.{}, BufferWaiter.run, .{ &sample_mux, &done_event, &buffers });
 
     // Check thread is blocking
@@ -1126,7 +1127,7 @@ test "ThreadSafeRingBufferSampleMux blocking write" {
     try std.testing.expectError(error.Timeout, sample_mux.wait(ts, std.time.ns_per_ms));
 
     const BufferWaiter = struct {
-        fn run(sm: *SampleMux, done: *std.Thread.ResetEvent, _buffers: *SampleMux.SampleBuffers(ts)) !void {
+        fn run(sm: *SampleMux, done: *sync.ResetEvent, _buffers: *SampleMux.SampleBuffers(ts)) !void {
             // Wait for update buffers
             _buffers.* = try sm.get(ts);
             // Signal done
@@ -1136,7 +1137,7 @@ test "ThreadSafeRingBufferSampleMux blocking write" {
 
     // Spawn a thread that blocks until sample buffers are available
     var buffers: SampleMux.SampleBuffers(ts) = undefined;
-    var done_event = std.Thread.ResetEvent{};
+    var done_event = sync.ResetEvent{};
     var thread = try std.Thread.spawn(.{}, BufferWaiter.run, .{ &sample_mux, &done_event, &buffers });
 
     // Check thread is blocking

--- a/src/core/sync.zig
+++ b/src/core/sync.zig
@@ -1,0 +1,107 @@
+const std = @import("std");
+
+// Zig 0.16 removed std.Thread.Mutex / std.Thread.Condition / std.Thread.ResetEvent
+// (and std.Thread.sleep) in favor of the new std.Io-based primitives, which
+// require threading an `io` handle through every call site. To keep the
+// migration minimal, this module provides drop-in replacements backed by
+// pthreads (libC is always linked by this project).
+
+extern "c" fn clock_gettime(clk_id: std.c.clockid_t, tp: *std.c.timespec) c_int;
+
+fn deadlineFromNow(timeout_ns: u64) std.c.timespec {
+    var ts: std.c.timespec = undefined;
+    _ = clock_gettime(std.c.CLOCK.REALTIME, &ts);
+
+    const ns_per_s = std.time.ns_per_s;
+    const total_nsec = @as(u64, @intCast(ts.nsec)) + (timeout_ns % ns_per_s);
+    ts.sec += @intCast(timeout_ns / ns_per_s + total_nsec / ns_per_s);
+    ts.nsec = @intCast(total_nsec % ns_per_s);
+    return ts;
+}
+
+pub fn sleep(nanoseconds: u64) void {
+    const ts: std.c.timespec = .{
+        .sec = @intCast(nanoseconds / std.time.ns_per_s),
+        .nsec = @intCast(nanoseconds % std.time.ns_per_s),
+    };
+    _ = std.c.nanosleep(&ts, null);
+}
+
+pub const Mutex = struct {
+    inner: std.c.pthread_mutex_t = .{},
+
+    pub fn lock(self: *Mutex) void {
+        _ = std.c.pthread_mutex_lock(&self.inner);
+    }
+
+    pub fn unlock(self: *Mutex) void {
+        _ = std.c.pthread_mutex_unlock(&self.inner);
+    }
+};
+
+pub const Condition = struct {
+    inner: std.c.pthread_cond_t = .{},
+
+    pub fn wait(self: *Condition, mutex: *Mutex) void {
+        _ = std.c.pthread_cond_wait(&self.inner, &mutex.inner);
+    }
+
+    pub fn timedWait(self: *Condition, mutex: *Mutex, timeout_ns: u64) error{Timeout}!void {
+        const deadline = deadlineFromNow(timeout_ns);
+        if (std.c.pthread_cond_timedwait(&self.inner, &mutex.inner, &deadline) == .TIMEDOUT) {
+            return error.Timeout;
+        }
+    }
+
+    pub fn signal(self: *Condition) void {
+        _ = std.c.pthread_cond_signal(&self.inner);
+    }
+
+    pub fn broadcast(self: *Condition) void {
+        _ = std.c.pthread_cond_broadcast(&self.inner);
+    }
+};
+
+pub const ResetEvent = struct {
+    mutex: Mutex = .{},
+    cond: Condition = .{},
+    is_set: bool = false,
+
+    pub fn isSet(self: *ResetEvent) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return self.is_set;
+    }
+
+    pub fn set(self: *ResetEvent) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.is_set = true;
+        self.cond.broadcast();
+    }
+
+    pub fn reset(self: *ResetEvent) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.is_set = false;
+    }
+
+    pub fn wait(self: *ResetEvent) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        while (!self.is_set) self.cond.wait(&self.mutex);
+    }
+
+    pub fn timedWait(self: *ResetEvent, timeout_ns: u64) error{Timeout}!void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.is_set) return;
+
+        const deadline = deadlineFromNow(timeout_ns);
+        while (!self.is_set) {
+            if (std.c.pthread_cond_timedwait(&self.cond.inner, &self.mutex.inner, &deadline) == .TIMEDOUT) {
+                if (!self.is_set) return error.Timeout;
+            }
+        }
+    }
+};

--- a/src/core/testing.zig
+++ b/src/core/testing.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 
+extern "c" fn clock_gettime(clk_id: std.c.clockid_t, tp: *std.c.timespec) c_int;
+
 const util = @import("util.zig");
 const platform = @import("platform.zig");
 
@@ -268,12 +270,16 @@ pub fn BlockFixture(comptime input_data_types: []const type, comptime output_dat
 ////////////////////////////////////////////////////////////////////////////////
 
 pub const TemporaryFile = struct {
-    file: std.fs.File,
+    io: std.Io,
+    file: std.Io.File,
 
-    pub fn create() !TemporaryFile {
+    pub fn create(io: std.Io) !TemporaryFile {
         // Generate random filename
         var random_bytes: [12]u8 = undefined;
-        std.crypto.random.bytes(&random_bytes);
+        var ts: std.c.timespec = undefined;
+        _ = clock_gettime(std.c.CLOCK.REALTIME, &ts);
+        var prng = std.Random.DefaultPrng.init(@bitCast(@as(i64, ts.nsec) *% 1_000_000_007 +% @as(i64, ts.sec)));
+        prng.random().bytes(&random_bytes);
         var random_name: [std.fs.base64_encoder.calcSize(random_bytes.len)]u8 = undefined;
         _ = std.fs.base64_encoder.encode(&random_name, &random_bytes);
 
@@ -282,31 +288,31 @@ pub const TemporaryFile = struct {
         defer std.testing.allocator.free(random_file_path);
 
         // Create the file
-        const file = try std.fs.createFileAbsolute(random_file_path, .{ .read = true });
+        const file = try std.Io.Dir.createFileAbsolute(io, random_file_path, .{ .read = true });
         // Unlink the file
-        try std.fs.deleteFileAbsolute(random_file_path);
+        try std.Io.Dir.deleteFileAbsolute(io, random_file_path);
 
-        return .{ .file = file };
+        return .{ .io = io, .file = file };
     }
 
     pub fn write(self: *TemporaryFile, data: []const u8) !void {
         // Truncate file
-        try self.file.setEndPos(0);
+        try self.file.setLength(self.io, 0);
 
         // Write file
-        var writer = self.file.writer(&.{});
+        var writer = self.file.writer(self.io, &.{});
         try writer.interface.writeAll(data);
         try writer.interface.flush();
     }
 
     pub fn read(self: *TemporaryFile, buffer: []u8) !usize {
         // Read file
-        var reader = self.file.reader(&.{});
+        var reader = self.file.reader(self.io, &.{});
         return try reader.interface.readSliceShort(buffer);
     }
 
     pub fn close(self: *TemporaryFile) void {
-        self.file.close();
+        self.file.close(self.io);
     }
 };
 
@@ -570,17 +576,21 @@ test "BlockFixture for Source" {
 }
 
 test "TemporaryFile low-level write/read" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
     // Create temporary file
-    var tmpfile = try TemporaryFile.create();
+    var tmpfile = try TemporaryFile.create(io);
     defer tmpfile.close();
 
     // Write to file
-    var writer = tmpfile.file.writer(&.{});
+    var writer = tmpfile.file.writer(io, &.{});
     try writer.interface.writeAll("testing");
     try writer.interface.flush();
 
     // Read from file
-    var reader = tmpfile.file.reader(&.{});
+    var reader = tmpfile.file.reader(io, &.{});
     var buf: [16]u8 = undefined;
     const count = try reader.interface.readSliceShort(&buf);
 
@@ -589,8 +599,12 @@ test "TemporaryFile low-level write/read" {
 }
 
 test "TemporaryFile high-level write/read" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
     // Create temporary file
-    var tmpfile = try TemporaryFile.create();
+    var tmpfile = try TemporaryFile.create(io);
     defer tmpfile.close();
 
     // Write

--- a/src/core/types.zig
+++ b/src/core/types.zig
@@ -142,7 +142,7 @@ test "ComptimeTypeSignature.init" {
     const TestProcess00 = struct {
         fn process(_: *@This()) void {}
     };
-    const ts00 = ComptimeTypeSignature.init(TestProcess00.process);
+    const ts00 = comptime ComptimeTypeSignature.init(TestProcess00.process);
     try std.testing.expectEqual(0, ts00.inputs.len);
     try std.testing.expectEqual(0, ts00.outputs.len);
 
@@ -150,7 +150,7 @@ test "ComptimeTypeSignature.init" {
     const TestProcess10 = struct {
         fn process(_: *@This(), _: []const u32) void {}
     };
-    const ts10 = ComptimeTypeSignature.init(TestProcess10.process);
+    const ts10 = comptime ComptimeTypeSignature.init(TestProcess10.process);
     try std.testing.expectEqual(1, ts10.inputs.len);
     try std.testing.expectEqual(u32, ts10.inputs[0]);
     try std.testing.expectEqual(0, ts10.outputs.len);
@@ -159,7 +159,7 @@ test "ComptimeTypeSignature.init" {
     const TestProcess01 = struct {
         fn process(_: *@This(), _: []u32) void {}
     };
-    const ts01 = ComptimeTypeSignature.init(TestProcess01.process);
+    const ts01 = comptime ComptimeTypeSignature.init(TestProcess01.process);
     try std.testing.expectEqual(0, ts01.inputs.len);
     try std.testing.expectEqual(1, ts01.outputs.len);
     try std.testing.expectEqual(u32, ts01.outputs[0]);
@@ -168,7 +168,7 @@ test "ComptimeTypeSignature.init" {
     const TestProcess11 = struct {
         fn process(_: *@This(), _: []const u16, _: []u8) void {}
     };
-    const ts11 = ComptimeTypeSignature.init(TestProcess11.process);
+    const ts11 = comptime ComptimeTypeSignature.init(TestProcess11.process);
     try std.testing.expectEqual(1, ts11.inputs.len);
     try std.testing.expectEqual(u16, ts11.inputs[0]);
     try std.testing.expectEqual(1, ts11.outputs.len);
@@ -178,7 +178,7 @@ test "ComptimeTypeSignature.init" {
     const TestProcess22 = struct {
         fn process(_: *@This(), _: []const u16, _: []const u32, _: []u8, _: []bool) void {}
     };
-    const ts22 = ComptimeTypeSignature.init(TestProcess22.process);
+    const ts22 = comptime ComptimeTypeSignature.init(TestProcess22.process);
     try std.testing.expectEqual(2, ts22.inputs.len);
     try std.testing.expectEqual(u16, ts22.inputs[0]);
     try std.testing.expectEqual(u32, ts22.inputs[1]);
@@ -188,7 +188,7 @@ test "ComptimeTypeSignature.init" {
 }
 
 test "ComptimeTypeSignature.fromTypes" {
-    const ts = ComptimeTypeSignature.fromTypes(&[2]type{ f32, u16 }, &[1]type{u8});
+    const ts = comptime ComptimeTypeSignature.fromTypes(&[2]type{ f32, u16 }, &[1]type{u8});
     try std.testing.expectEqual(2, ts.inputs.len);
     try std.testing.expectEqual(f32, ts.inputs[0]);
     try std.testing.expectEqual(u16, ts.inputs[1]);

--- a/src/core/types.zig
+++ b/src/core/types.zig
@@ -11,10 +11,10 @@ pub const ComptimeTypeSignature = struct {
     pub fn init(comptime process_fn: anytype) ComptimeTypeSignature {
         const process_args = @typeInfo(@TypeOf(process_fn)).@"fn".params[1..];
 
-        var _comptime_inputs: [process_args.len]type = undefined;
-        var _comptime_outputs: [process_args.len]type = undefined;
-        var num_inputs: usize = 0;
-        var num_outputs: usize = 0;
+        comptime var _comptime_inputs: [process_args.len]type = undefined;
+        comptime var _comptime_outputs: [process_args.len]type = undefined;
+        comptime var num_inputs: usize = 0;
+        comptime var num_outputs: usize = 0;
 
         inline for (process_args) |arg| {
             const arg_is_input = @typeInfo(arg.type orelse unreachable).pointer.is_const;


### PR DESCRIPTION
Update for breaking std changes in Zig 0.16.0. Library and all examples build (zig build, zig build examples).

build:
- std.fs.cwd() -> std.Io.Dir.cwd() (now requires an io handle)
- drop exe.linkLibC(); set .link_libc = true on the module instead

std API renames/moves:
- std.heap.GeneralPurposeAllocator -> std.heap.DebugAllocator
- std.io.{Reader,Writer} -> std.Io.{Reader,Writer}
- std.math.sign removed -> std.math.copysign
- std.posix.{close,ftruncate} removed -> std.c.{close,ftruncate}
- std.posix.PROT.{READ,WRITE} flags -> PROT packed-struct literal
- std.process.getEnvVarOwned removed -> std.c.getenv
- std.AutoArrayHashMap (managed) removed -> local managed wrapper over std.AutoArrayHashMapUnmanaged
- stricter comptime: mark type-array/counter vars comptime in ComptimeTypeSignature.init; force comptime signature derivation in Block.init

concurrency (std.Thread.{Mutex,Condition,ResetEvent,sleep} removed; 0.16 moved these to std.Io requiring an io handle, and dropped ResetEvent/Condition.timedWait entirely):
- add src/core/sync.zig: pthread-backed Mutex/Condition/ResetEvent
  + sleep drop-in shim (libC always linked), preserving timedWait semantics with no call-site churn
- swap std.Thread.* sync primitives for sync.* across runner, ring_buffer, sample_mux, flowgraph, application source/sink

examples: "Juicy Main"
- main now takes std.process.Init; allocator from init.gpa
- args via std.process.Args.Iterator (argsAlloc removed); file I/O in iqfile_converter uses init.io
- std.posix.exit -> std.process.exit